### PR TITLE
Use the Luanti name in places where forgotten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ContentDB
 ![Build Status](https://github.com/minetest/contentdb/actions/workflows/test.yml/badge.svg)
 
-A content database for Minetest mods, games, and more.\
+A content database for Luanti mods, games, and more.\
 Developed by rubenwardy, license AGPLv3.0+.
 
 See [Getting Started](docs/getting_started.md) for setting up a development/prodiction environment.

--- a/app/public/static/js/package_edit.js
+++ b/app/public/static/js/package_edit.js
@@ -68,8 +68,9 @@ window.addEventListener("load", () => {
 	}
 
 	setupHints("short_desc", {
-		"short_desc_mods": (val) => val.indexOf("minetest") >= 0 || val.indexOf("mod") >= 0 ||
-				val.indexOf("modpack") >= 0 || val.indexOf("mod pack") >= 0,
+		"short_desc_mods": (val) => val.indexOf("luanti") >= 0 || val.indexOf("minetest") >= 0 ||
+				val.indexOf("mod") >= 0 || val.indexOf("modpack") >= 0 ||
+				val.indexOf("mod pack") >= 0,
 	});
 
 	setupHints("desc", {

--- a/app/templates/packages/create_edit.html
+++ b/app/templates/packages/create_edit.html
@@ -82,7 +82,7 @@
 			</div>
 			{{ render_field(form.short_desc, class_="pkg_meta") }}
 			<p class="form-text text-warning d-none" id="short_desc_mods">
-				{{ _("Tip: Don't include <i>Minetest</i>, <i>mod</i>, or <i>modpack</i> anywhere in the short description. It is unnecessary and wastes characters.") }}
+				{{ _("Tip: Don't include <i>Luanti</i>, <i>Minetest</i>, <i>mod</i>, or <i>modpack</i> anywhere in the short description. It is unnecessary and wastes characters.") }}
 			</p>
 
 			{{ render_field(form.dev_state, class_="pkg_meta", hint=_("Please choose 'Work in Progress' if your package is unstable, and shouldn't be recommended to all players")) }}

--- a/docs/minetest_client.md
+++ b/docs/minetest_client.md
@@ -1,6 +1,6 @@
-# Minetest's use of the API
+# Luanti's use of the API
 
-This document explains how Minetest's ContentDB client interacts with ContentDB.
+This document explains how Luanti's ContentDB client interacts with ContentDB.
 This is useful both for implementing your own client for ContentDB to install mods, 
 or for implementing ContentDB compatible servers.
 
@@ -36,7 +36,7 @@ Example response:
 `type` is one of `mod`, `game`, or `txp`.
 
 `release` is the release ID. Newer releases have higher IDs.
-Minetest compares this ID to a locally stored version to detect whether a package has updates.
+Luanti compares this ID to a locally stored version to detect whether a package has updates.
 
 Because the client specifies the engine version information, the response must contain a release
 number and the package must be downloadable.
@@ -62,7 +62,7 @@ track the installed release to detect updates in the future.
 
 ### Short version
 
-Minetest uses `/api/packages/<author>/<name>/dependencies/?only_hard=1` to find out the hard
+Luanti uses `/api/packages/<author>/<name>/dependencies/?only_hard=1` to find out the hard
 dependencies for a package.
 
 Then, it resolves each dependency recursively. 


### PR DESCRIPTION
This small PR switches to the Luanti name in a few places where the old Minetest name is still used.

* README
* The warning you shouldn't use "Minetest" name in the short description now also checks for Luanti name
* `minetest_client.md` (file itself not renamed to not break links)