### PR TITLE
Add a state enum, and store phash+dhash in PackageContentDetection for non-unique indexing to match

### DIFF
--- a/app/models/packages.py
+++ b/app/models/packages.py
@@ -1651,15 +1651,41 @@ class PackageDailyStats(db.Model):
 		conn.execute(stmt)
 
 
+class ContentDetectionState(enum.Enum):
+	NEW = "New"
+	IGNORED = "Ignored"
+	ACCEPTED = "Accepted"
+
+	def to_name(self):
+		return self.name.lower()
+
+	def __str__(self):
+		return self.name
+
+
 class PackageContentDetection(db.Model):
+	__table_args__ = (
+		# Not unique: the same texture can appear at multiple content_paths.
+		# Rescan dedupe against a prior review is done in application code via this index.
+		db.Index("ix_package_content_detection_package_hash", "package_id", "content_phash", "content_dhash"),
+	)
+
 	id           = db.Column(db.Integer, primary_key=True)
 
 	package_id   = db.Column(db.Integer, db.ForeignKey("package.id"))
 	package      = db.relationship("Package", back_populates="content_detections", foreign_keys=[package_id])
 
 	content_path = db.Column(db.String(200), nullable=False)
+
+	# Identifies the texture across rescans, independent of content_path.
+	content_phash = db.Column(db.String(200), nullable=False)
+	content_dhash = db.Column(db.String(200), nullable=False)
+
 	match_path = db.Column(db.String(200), nullable=False)
 	confidence = db.Column(db.Float, nullable=False)
+
+	state = db.Column(db.Enum(ContentDetectionState), nullable=False, default=ContentDetectionState.NEW)
+
 	created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
 
 

--- a/migrations/versions/f4010cc844cf_.py
+++ b/migrations/versions/f4010cc844cf_.py
@@ -17,6 +17,9 @@ depends_on = None
 
 
 def upgrade():
+    status = postgresql.ENUM('NEW', 'IGNORED', 'ACCEPTED', name='contentdetectionstate')
+    status.create(op.get_bind())
+
     op.create_table('content_detection_dataset',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('name', sa.String(length=200), nullable=False),
@@ -38,12 +41,17 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('package_id', sa.Integer(), nullable=True),
     sa.Column('content_path', sa.String(length=200), nullable=False),
+    sa.Column('content_phash', sa.String(length=200), nullable=False),
+    sa.Column('content_dhash', sa.String(length=200), nullable=False),
     sa.Column('match_path', sa.String(length=200), nullable=False),
     sa.Column('confidence', sa.Float(), nullable=False),
+    sa.Column('state', sa.Enum('NEW', 'IGNORED', 'ACCEPTED', name='contentdetectionstate'), nullable=False),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.ForeignKeyConstraint(['package_id'], ['package.id'], ),
     sa.PrimaryKeyConstraint('id')
     )
+    op.create_index('ix_package_content_detection_package_hash', 'package_content_detection',
+        ['package_id', 'content_phash', 'content_dhash'])
     op.create_table('content_detection_dataset_entry_hash',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('dataset_entry_id', sa.Integer(), nullable=True),
@@ -56,6 +64,9 @@ def upgrade():
 
 def downgrade():
     op.drop_table('content_detection_dataset_entry_hash')
+    op.drop_index('ix_package_content_detection_package_hash', table_name='package_content_detection')
     op.drop_table('package_content_detection')
     op.drop_table('content_detection_dataset_entry')
     op.drop_table('content_detection_dataset')
+
+    postgresql.ENUM(name='contentdetectionstate').drop(op.get_bind())


### PR DESCRIPTION
NOTE: this targets the WIP `content-detection branch`, not `master`

- New enum for ContentDetection - New/Ignored/Accepted
- Store phash and dhash in each PackageContentDetection class
- Add new columns to migration script

Note: I had to get claude help with the sql migration and some syntax, sql ain't my thing.