### PR TITLE
Add hashchecking based on check package script

### DIFF
--- a/app/blueprints/admin/actions.py
+++ b/app/blueprints/admin/actions.py
@@ -19,7 +19,7 @@ from app.tasks.admintasks import delete_empty_threads
 from app.tasks.emails import send_pending_digests
 from app.tasks.forumtasks import import_topic_list, check_all_forum_accounts
 from app.tasks.importtasks import import_repo_screenshot, check_zip_release, check_for_updates, update_all_game_support, \
-	import_languages, check_all_zip_files, update_all_release_permissions
+	import_languages, check_all_zip_files, update_all_release_permissions, detect_content_in_release
 from app.tasks.usertasks import import_github_user_ids
 from app.tasks.pkgtasks import notify_about_git_forum_links, clear_removed_packages, check_package_for_broken_links, update_file_size_bytes
 from app.tasks.dumptask import create_database_dump
@@ -329,6 +329,14 @@ def do_update_file_size_bytes():
 def do_create_database_dump():
 	task_id = uuid()
 	create_database_dump.apply_async((), task_id=task_id)
+	return redirect(url_for("tasks.check", id=task_id, r=url_for("admin.admin_page")))
+
+
+@action("Run content checker on all packages")
+def do_run_content_checker_on_all_packages():
+	task_id = uuid()
+	release_id = 38467
+	detect_content_in_release.apply_async((release_id,), task_id=task_id)
 	return redirect(url_for("tasks.check", id=task_id, r=url_for("admin.admin_page")))
 
 

--- a/app/blueprints/admin/content_detection.py
+++ b/app/blueprints/admin/content_detection.py
@@ -13,7 +13,7 @@ import json
 
 from . import bp
 from app.models import db, ContentDetectionDataset, UserRank, ContentDetectionDatasetEntry, \
-	ContentDetectionDatasetEntryHash
+	ContentDetectionDatasetEntryHash, PackageContentDetection, ContentDetectionState
 from app.utils.user import rank_required
 
 
@@ -58,3 +58,21 @@ def cd_datasets():
 		handle_update(data)
 
 	return render_template("admin/content_detection/datasets.html", form=form, datasets=ContentDetectionDataset.query.all())
+
+
+@bp.route("/admin/content_detection/matches/", methods=["GET"])
+@rank_required(UserRank.EDITOR)
+def cd_matches():
+	matches = (PackageContentDetection.query
+		.filter(PackageContentDetection.state != ContentDetectionState.IGNORED)
+		.order_by(PackageContentDetection.confidence.asc())
+		.all())
+	return render_template("admin/content_detection/match_list.html", matches=matches)
+
+
+@bp.route("/admin/content_detection/matches/<int:match_id>/", methods=["GET"])
+@rank_required(UserRank.EDITOR)
+def cd_match(match_id):
+	match = PackageContentDetection.query.get_or_404(match_id)
+
+	return render_template("admin/content_detection/match.html", match=match)

--- a/app/models/packages.py
+++ b/app/models/packages.py
@@ -1711,7 +1711,7 @@ class ContentDetectionDatasetEntry(db.Model):
 	created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
 
 	hashes = db.relationship("ContentDetectionDatasetEntryHash", back_populates="dataset_entry",
-			lazy="dynamic", cascade="all, delete, delete-orphan")
+			cascade="all, delete, delete-orphan")
 
 
 class ContentDetectionDatasetEntryHash(db.Model):

--- a/app/models/packages.py
+++ b/app/models/packages.py
@@ -6,6 +6,7 @@
 import datetime
 import enum
 import os
+import base64
 
 import typing
 from flask import url_for
@@ -1676,10 +1677,9 @@ class PackageContentDetection(db.Model):
 	package      = db.relationship("Package", back_populates="content_detections", foreign_keys=[package_id])
 
 	content_path = db.Column(db.String(200), nullable=False)
-
-	# Identifies the texture across rescans, independent of content_path.
 	content_phash = db.Column(db.String(200), nullable=False)
 	content_dhash = db.Column(db.String(200), nullable=False)
+	content_data = db.Column(db.LargeBinary, nullable=False)
 
 	match_path = db.Column(db.String(200), nullable=False)
 	confidence = db.Column(db.Float, nullable=False)
@@ -1687,6 +1687,10 @@ class PackageContentDetection(db.Model):
 	state = db.Column(db.Enum(ContentDetectionState), nullable=False, default=ContentDetectionState.NEW)
 
 	created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+
+	@property
+	def content_as_data_url(self):
+		return "data:image/png;base64," + base64.b64encode(self.content_data).decode("utf-8")
 
 
 class ContentDetectionDataset(db.Model):

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -34,7 +34,7 @@ class PossibleMatch:
 
 	# Hash of the content_path image, so callers can dedupe/persist without re-hashing
 	content_phash: str
-	content_dhash: st
+	content_dhash: str
 	content_data: bytes
 
 

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 rubenwardy <rw@rubenwardy>
 
+import os
 from dataclasses import dataclass
 from io import BytesIO
-from typing import List, Optional
+from typing import Callable, List, Optional
 from zipfile import ZipFile
 
 import imagehash
@@ -74,42 +75,73 @@ def best_distance(phash: int, dhash: int, entry: DatasetEntry) -> Optional[float
 	return best
 
 
-def find_matches(
+def find_matches_in_zip(
 		zip_file_path: str, entries: List[DatasetEntry],
-		threshold: float = DEFAULT_THRESHOLD, max_matches: int = MAX_MATCHES_PER_IMAGE
+		threshold: float = DEFAULT_THRESHOLD,
+		max_matches: int = MAX_MATCHES_PER_IMAGE
 ) -> List[PossibleMatch]:
-	results = []
 	with ZipFile(zip_file_path, 'r') as zf:
 		image_names = [name for name in zf.namelist() if name.lower().endswith(IMAGE_EXTS)]
-		for name in image_names:
+
+		def load_image(name: str) -> Image.Image:
 			with zf.open(name) as f:
-				try:
-					img = Image.open(BytesIO(f.read())).convert("RGBA")
-				except Exception:
-					continue
+				return Image.open(BytesIO(f.read())).convert("RGBA")
 
-			phash_obj = imagehash.phash(img, hash_size=16)
-			dhash_obj = imagehash.dhash(img, hash_size=16)
-			phash = hash_to_int(phash_obj)
-			dhash = hash_to_int(dhash_obj)
+		return _find_matches(image_names, load_image, entries, threshold, max_matches)
 
-			# TODO: skip solid/flat-color images here
 
-			candidates = []
-			for entry in entries:
-				dist = best_distance(phash, dhash, entry)
-				if dist is not None and dist <= threshold:
-					candidates.append((dist, entry))
-			candidates.sort(key=lambda cand: cand[0])
+def find_matches_in_dir(
+		dir_path: str, entries: List[DatasetEntry],
+		threshold: float = DEFAULT_THRESHOLD,
+		max_matches: int = MAX_MATCHES_PER_IMAGE
+) -> List[PossibleMatch]:
+	image_names = [
+		os.path.relpath(os.path.join(root, f), dir_path)
+		for root, _, files in os.walk(dir_path) # Todo maybe: Skip hidden folders like .git?
+		for f in files if f.lower().endswith(IMAGE_EXTS)
+	]
 
-			for dist, entry in candidates[:max_matches]:
-				results.append(PossibleMatch(
-					content_path=name,
-					match_dataset=entry.dataset,
-					match_path=entry.path,
-					confidence=dist,
-					content_phash=str(phash_obj),
-					content_dhash=str(dhash_obj),
-				))
+	def load_image(name: str) -> Image.Image:
+		return Image.open(os.path.join(dir_path, name)).convert("RGBA")
+
+	return _find_matches(image_names, load_image, entries, threshold, max_matches)
+
+
+def _find_matches(
+		image_names: List[str],
+		load_image: Callable[[str], Image.Image],
+		entries: List[DatasetEntry],
+		threshold: float, max_matches: int
+) -> List[PossibleMatch]:
+	results = []
+	for name in image_names:
+		try:
+			img = load_image(name)
+		except Exception:
+			continue
+
+		phash_obj = imagehash.phash(img, hash_size=16)
+		dhash_obj = imagehash.dhash(img, hash_size=16)
+		phash = hash_to_int(phash_obj)
+		dhash = hash_to_int(dhash_obj)
+
+		# TODO: skip solid/flat-color images here
+
+		candidates = []
+		for entry in entries:
+			dist = best_distance(phash, dhash, entry)
+			if dist is not None and dist <= threshold:
+				candidates.append((dist, entry))
+		candidates.sort(key=lambda cand: cand[0])
+
+		for dist, entry in candidates[:max_matches]:
+			results.append(PossibleMatch(
+				content_path=name,
+				match_dataset=entry.dataset,
+				match_path=entry.path,
+				confidence=dist,
+				content_phash=str(phash_obj),
+				content_dhash=str(dhash_obj),
+			))
 
 	return results

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from io import BytesIO
 from typing import Callable, List, Optional
 from zipfile import ZipFile
-
+import sys
 import imagehash
 import numpy
 from PIL import Image
@@ -115,6 +115,8 @@ def _find_matches(
 ) -> List[PossibleMatch]:
 	results = []
 	for name in image_names:
+		print(f"Checking {name}...", file=sys.stderr)
+
 		try:
 			img = load_image(name)
 		except Exception:

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -34,7 +34,8 @@ class PossibleMatch:
 
 	# Hash of the content_path image, so callers can dedupe/persist without re-hashing
 	content_phash: str
-	content_dhash: str
+	content_dhash: st
+	content_data: bytes
 
 
 @dataclass
@@ -137,6 +138,8 @@ def _find_matches(
 		candidates.sort(key=lambda cand: cand[0])
 
 		for dist, entry in candidates[:max_matches]:
+			content_buffer = BytesIO()
+			img.save(content_buffer, format="PNG")
 			results.append(PossibleMatch(
 				content_path=name,
 				match_dataset=entry.dataset,
@@ -144,6 +147,7 @@ def _find_matches(
 				confidence=dist,
 				content_phash=str(phash_obj),
 				content_dhash=str(dhash_obj),
+				content_data=content_buffer.getvalue()
 			))
 
 	return results

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -14,6 +14,7 @@ from PIL import Image
 IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".tga", ".bmp")
 
 DEFAULT_THRESHOLD = 8
+MAX_MATCHES_PER_IMAGE = 5
 
 
 @dataclass
@@ -73,8 +74,10 @@ def best_distance(phash: int, dhash: int, entry: DatasetEntry) -> Optional[float
 	return best
 
 
-def find_matches(zip_file_path: str, entries: List[DatasetEntry],
-		threshold: float = DEFAULT_THRESHOLD) -> List[PossibleMatch]:
+def find_matches(
+		zip_file_path: str, entries: List[DatasetEntry],
+		threshold: float = DEFAULT_THRESHOLD, max_matches: int = MAX_MATCHES_PER_IMAGE
+) -> List[PossibleMatch]:
 	results = []
 	with ZipFile(zip_file_path, 'r') as zf:
 		image_names = [name for name in zf.namelist() if name.lower().endswith(IMAGE_EXTS)]
@@ -92,16 +95,21 @@ def find_matches(zip_file_path: str, entries: List[DatasetEntry],
 
 			# TODO: skip solid/flat-color images here
 
+			candidates = []
 			for entry in entries:
 				dist = best_distance(phash, dhash, entry)
 				if dist is not None and dist <= threshold:
-					results.append(PossibleMatch(
-						content_path=name,
-						match_dataset=entry.dataset,
-						match_path=entry.path,
-						confidence=dist,
-						content_phash=str(phash_obj),
-						content_dhash=str(dhash_obj),
-					))
+					candidates.append((dist, entry))
+			candidates.sort(key=lambda cand: cand[0])
+
+			for dist, entry in candidates[:max_matches]:
+				results.append(PossibleMatch(
+					content_path=name,
+					match_dataset=entry.dataset,
+					match_path=entry.path,
+					confidence=dist,
+					content_phash=str(phash_obj),
+					content_dhash=str(dhash_obj),
+				))
 
 	return results

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -5,7 +5,7 @@
 import os
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Callable, List, Optional
+from typing import List, Optional
 from zipfile import ZipFile
 import sys
 import imagehash
@@ -81,14 +81,20 @@ def find_matches_in_zip(
 		threshold: float = DEFAULT_THRESHOLD,
 		max_matches: int = MAX_MATCHES_PER_IMAGE
 ) -> List[PossibleMatch]:
+	results = []
 	with ZipFile(zip_file_path, 'r') as zf:
 		image_names = [name for name in zf.namelist() if name.lower().endswith(IMAGE_EXTS)]
 
-		def load_image(name: str) -> Image.Image:
-			with zf.open(name) as f:
-				return Image.open(BytesIO(f.read())).convert("RGBA")
+		for name in image_names:
+			try:
+				with zf.open(name) as f:
+					img = Image.open(BytesIO(f.read())).convert("RGBA")
+			except Exception:
+				continue
 
-		return _find_matches(image_names, load_image, entries, threshold, max_matches)
+			results.extend(process_image(name, img, entries, threshold, max_matches))
+
+	return results
 
 
 def find_matches_in_dir(
@@ -102,52 +108,51 @@ def find_matches_in_dir(
 		for f in files if f.lower().endswith(IMAGE_EXTS)
 	]
 
-	def load_image(name: str) -> Image.Image:
-		return Image.open(os.path.join(dir_path, name)).convert("RGBA")
-
-	return _find_matches(image_names, load_image, entries, threshold, max_matches)
-
-
-def _find_matches(
-		image_names: List[str],
-		load_image: Callable[[str], Image.Image],
-		entries: List[DatasetEntry],
-		threshold: float, max_matches: int
-) -> List[PossibleMatch]:
 	results = []
 	for name in image_names:
-		print(f"Checking {name}...", file=sys.stderr)
-
 		try:
-			img = load_image(name)
+			img = Image.open(os.path.join(dir_path, name)).convert("RGBA")
 		except Exception:
 			continue
 
-		phash_obj = imagehash.phash(img, hash_size=16)
-		dhash_obj = imagehash.dhash(img, hash_size=16)
-		phash = hash_to_int(phash_obj)
-		dhash = hash_to_int(dhash_obj)
+		results.extend(process_image(name, img, entries, threshold, max_matches))
 
-		# TODO: skip solid/flat-color images here
+	return results
 
-		candidates = []
-		for entry in entries:
-			dist = best_distance(phash, dhash, entry)
-			if dist is not None and dist <= threshold:
-				candidates.append((dist, entry))
-		candidates.sort(key=lambda cand: cand[0])
 
-		for dist, entry in candidates[:max_matches]:
-			content_buffer = BytesIO()
-			img.save(content_buffer, format="PNG")
-			results.append(PossibleMatch(
-				content_path=name,
-				match_dataset=entry.dataset,
-				match_path=entry.path,
-				confidence=dist,
-				content_phash=str(phash_obj),
-				content_dhash=str(dhash_obj),
-				content_data=content_buffer.getvalue()
-			))
+def process_image(
+		image_path: str, img: Image.Image,
+		entries: List[DatasetEntry],
+		threshold: float, max_matches: int
+) -> List[PossibleMatch]:
+	print(f"Checking {image_path}...", file=sys.stderr)
+
+	phash_obj = imagehash.phash(img, hash_size=16)
+	dhash_obj = imagehash.dhash(img, hash_size=16)
+	phash = hash_to_int(phash_obj)
+	dhash = hash_to_int(dhash_obj)
+
+	# TODO: skip solid/flat-color images here
+
+	candidates = []
+	for entry in entries:
+		dist = best_distance(phash, dhash, entry)
+		if dist is not None and dist <= threshold:
+			candidates.append((dist, entry))
+	candidates.sort(key=lambda cand: cand[0])
+
+	results = []
+	for dist, entry in candidates[:max_matches]:
+		content_buffer = BytesIO()
+		img.save(content_buffer, format="PNG")
+		results.append(PossibleMatch(
+			content_path=image_path,
+			match_dataset=entry.dataset,
+			match_path=entry.path,
+			confidence=dist,
+			content_phash=str(phash_obj),
+			content_dhash=str(dhash_obj),
+			content_data=content_buffer.getvalue()
+		))
 
 	return results

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -3,9 +3,17 @@
 # Copyright (C) 2026 rubenwardy <rw@rubenwardy>
 
 from dataclasses import dataclass
-from typing import List
+from io import BytesIO
+from typing import List, Optional
 from zipfile import ZipFile
+
 import imagehash
+import numpy
+from PIL import Image
+
+IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".tga", ".bmp")
+
+DEFAULT_THRESHOLD = 8
 
 
 @dataclass
@@ -38,11 +46,54 @@ class DatasetEntry:
 	hashes: List[Hash]
 
 
-def find_matches(zip_file_path: str, entries: List[DatasetEntry]) -> List[PossibleMatch]:
-	with ZipFile(zip_file_path, 'r') as zf:
-		lua_files = [name for name in zf.namelist() if name.endswith(".png")]
-		for lua_file in lua_files:
-			with zf.open(lua_file) as f:
-				pass
+def hash_to_int(h) -> int:
+	return int.from_bytes(numpy.packbits(h.hash.flatten()).tobytes(), "big")
 
-	return []
+
+def hamming(a: int, b: int) -> int:
+	return (a ^ b).bit_count()
+
+
+# Weighted toward whichever of phash/dhash agrees more.
+def combined_distance(phash_dist: int, dhash_dist: int) -> float:
+	smaller, larger = (phash_dist, dhash_dist) if phash_dist <= dhash_dist else (dhash_dist, phash_dist)
+	return (2 * smaller + larger) / 3
+
+
+def best_distance(phash: int, dhash: int, entry: DatasetEntry) -> Optional[float]:
+	best = None
+	for h in entry.hashes:
+		dist = combined_distance(hamming(phash, int(h.phash, 16)), hamming(dhash, int(h.dhash, 16)))
+		if best is None or dist < best:
+			best = dist
+	return best
+
+
+def find_matches(zip_file_path: str, entries: List[DatasetEntry],
+		threshold: float = DEFAULT_THRESHOLD) -> List[PossibleMatch]:
+	results = []
+	with ZipFile(zip_file_path, 'r') as zf:
+		image_names = [name for name in zf.namelist() if name.lower().endswith(IMAGE_EXTS)]
+		for name in image_names:
+			with zf.open(name) as f:
+				try:
+					img = Image.open(BytesIO(f.read())).convert("RGBA")
+				except Exception:
+					continue
+
+			phash = hash_to_int(imagehash.phash(img, hash_size=16))
+			dhash = hash_to_int(imagehash.dhash(img, hash_size=16))
+
+			# TODO: skip solid/flat-color images here
+
+			for entry in entries:
+				dist = best_distance(phash, dhash, entry)
+				if dist is not None and dist <= threshold:
+					results.append(PossibleMatch(
+						content_path=name,
+						match_dataset=entry.dataset,
+						match_path=entry.path,
+						confidence=dist,
+					))
+
+	return results

--- a/app/tasks/hashcheck/__init__.py
+++ b/app/tasks/hashcheck/__init__.py
@@ -30,6 +30,10 @@ class PossibleMatch:
 	# Confidence of match
 	confidence: float
 
+	# Hash of the content_path image, so callers can dedupe/persist without re-hashing
+	content_phash: str
+	content_dhash: str
+
 
 @dataclass
 class Hash:
@@ -81,8 +85,10 @@ def find_matches(zip_file_path: str, entries: List[DatasetEntry],
 				except Exception:
 					continue
 
-			phash = hash_to_int(imagehash.phash(img, hash_size=16))
-			dhash = hash_to_int(imagehash.dhash(img, hash_size=16))
+			phash_obj = imagehash.phash(img, hash_size=16)
+			dhash_obj = imagehash.dhash(img, hash_size=16)
+			phash = hash_to_int(phash_obj)
+			dhash = hash_to_int(dhash_obj)
 
 			# TODO: skip solid/flat-color images here
 
@@ -94,6 +100,8 @@ def find_matches(zip_file_path: str, entries: List[DatasetEntry],
 						match_dataset=entry.dataset,
 						match_path=entry.path,
 						confidence=dist,
+						content_phash=str(phash_obj),
+						content_dhash=str(dhash_obj),
 					))
 
 	return results

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -133,7 +133,7 @@ def update_all_release_permissions(self):
 
 	db.session.commit()
 
-from .hashcheck import find_matches, DatasetEntry, Hash
+from .hashcheck import find_matches_in_zip, DatasetEntry, Hash
 
 @celery.task()
 def detect_content_in_package(package_id: int):
@@ -153,7 +153,7 @@ def detect_content_in_package(package_id: int):
 	]
 
 	latest_release = package.get_download_release()
-	matches = find_matches(latest_release.file_path, entries)
+	matches = find_matches_in_zip(latest_release.file_path, entries)
 
 	# Keep only the closest match per (content_path, hash, match_path)
 	# Added content_path here in case two copies of same image appear in same package

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -195,14 +195,13 @@ def detect_content_in_release(release_id: int):
 		detection.content_path = match.content_path
 		detection.content_phash = match.content_phash
 		detection.content_dhash = match.content_dhash
+		detection.content_data = match.content_data
 		detection.match_path = match.match_path
 		detection.confidence = match.confidence
 		detection.state = ContentDetectionState.NEW
 		db.session.add(detection)
 
 	db.session.commit()
-	return "OK"
-
 
 
 def post_release_check_update(self, release: PackageRelease, path):

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -155,28 +155,36 @@ def detect_content_in_package(package_id: int):
 	latest_release = package.get_download_release()
 	matches = find_matches(latest_release.file_path, entries)
 
-	# Keep only the closest match per hash, in case one texture matches multiple entries
-	best_by_hash = {}
+	# Keep only the closest match per (content_path, hash, match_path)
+	# Added content_path here in case two copies of same image appear in same package
+	best_by_match = {}
 	for match in matches:
-		key = (match.content_phash, match.content_dhash)
-		current = best_by_hash.get(key)
+		key = (match.content_path, match.content_phash, match.content_dhash, match.match_path)
+		current = best_by_match.get(key)
 		if current is None or match.confidence < current.confidence:
-			best_by_hash[key] = match
+			best_by_match[key] = match
 
-	for match in best_by_hash.values():
-		existing = PackageContentDetection.query.filter_by(
-			package_id=package_id,
-			content_phash=match.content_phash,
-			content_dhash=match.content_dhash,
-		).first()
+	existing_detections = PackageContentDetection.query.filter_by(package_id=package_id).all()
+
+	# Path-independent so a texture reviewed under an old content_path should still
+	# count as reviewed for the same hash + match_path if moved
+	reviewed_hashes = {
+		(d.content_phash, d.content_dhash, d.match_path)
+		for d in existing_detections if d.state != ContentDetectionState.NEW
+	}
+	existing_new_by_match = {
+		(d.content_path, d.content_phash, d.content_dhash, d.match_path): d
+		for d in existing_detections if d.state == ContentDetectionState.NEW
+	}
+
+	for match in best_by_match.values():
+		if (match.content_phash, match.content_dhash, match.match_path) in reviewed_hashes:
+			continue
+
+		existing = existing_new_by_match.get(
+			(match.content_path, match.content_phash, match.content_dhash, match.match_path))
 
 		if existing is not None:
-			# Already reviewed - leave the reviewer's decision alone, don't re-flag it
-			if existing.state != ContentDetectionState.NEW:
-				continue
-
-			existing.content_path = match.content_path
-			existing.match_path = match.match_path
 			existing.confidence = match.confidence
 			continue
 

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -157,15 +157,6 @@ def detect_content_in_release(release_id: int):
 
 	matches = find_matches_in_zip(release.file_path, entries)
 
-	# Keep only the closest match per (content_path, hash, match_path)
-	# Added content_path here in case two copies of same image appear in same package
-	best_by_match = {}
-	for match in matches:
-		key = (match.content_path, match.content_phash, match.content_dhash, match.match_path)
-		current = best_by_match.get(key)
-		if current is None or match.confidence < current.confidence:
-			best_by_match[key] = match
-
 	existing_detections = PackageContentDetection.query.filter_by(package_id=package.id).all()
 
 	# Path-independent so a texture reviewed under an old content_path should still
@@ -179,7 +170,7 @@ def detect_content_in_release(release_id: int):
 		for d in existing_detections if d.state == ContentDetectionState.NEW
 	}
 
-	for match in best_by_match.values():
+	for match in matches:
 		if (match.content_phash, match.content_dhash, match.match_path) in reviewed_hashes:
 			continue
 

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -21,7 +21,7 @@ from sqlalchemy.dialects.postgresql import insert
 from app.models import AuditSeverity, db, NotificationType, PackageRelease, MetaPackage, Dependency, PackageType, \
 	LuantiRelease, Package, PackageState, PackageScreenshot, PackageUpdateTrigger, PackageUpdateConfig, \
 	PackageGameSupport, PackageTranslation, Language, ReleaseState, ContentDetectionDatasetEntry, \
-	ContentDetectionDataset
+	ContentDetectionDataset, PackageContentDetection, ContentDetectionState
 from app.tasks import celery, TaskError
 from app.utils.misc import random_string, truncate_string
 from app.utils.models import post_bot_message, add_system_notification, add_system_audit_log, \
@@ -153,7 +153,44 @@ def detect_content_in_package(package_id: int):
 	]
 
 	latest_release = package.get_download_release()
-	find_matches(latest_release.file_path, entries)
+	matches = find_matches(latest_release.file_path, entries)
+
+	# Keep only the closest match per hash, in case one texture matches multiple entries
+	best_by_hash = {}
+	for match in matches:
+		key = (match.content_phash, match.content_dhash)
+		current = best_by_hash.get(key)
+		if current is None or match.confidence < current.confidence:
+			best_by_hash[key] = match
+
+	for match in best_by_hash.values():
+		existing = PackageContentDetection.query.filter_by(
+			package_id=package_id,
+			content_phash=match.content_phash,
+			content_dhash=match.content_dhash,
+		).first()
+
+		if existing is not None:
+			# Already reviewed - leave the reviewer's decision alone, don't re-flag it
+			if existing.state != ContentDetectionState.NEW:
+				continue
+
+			existing.content_path = match.content_path
+			existing.match_path = match.match_path
+			existing.confidence = match.confidence
+			continue
+
+		detection = PackageContentDetection()
+		detection.package_id = package_id
+		detection.content_path = match.content_path
+		detection.content_phash = match.content_phash
+		detection.content_dhash = match.content_dhash
+		detection.match_path = match.match_path
+		detection.confidence = match.confidence
+		detection.state = ContentDetectionState.NEW
+		db.session.add(detection)
+
+	db.session.commit()
 
 
 

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -17,6 +17,7 @@ from git_archive_all import GitArchiver
 from kombu import uuid
 from sqlalchemy import and_, or_
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import subqueryload
 
 from app.models import AuditSeverity, db, NotificationType, PackageRelease, MetaPackage, Dependency, PackageType, \
 	LuantiRelease, Package, PackageState, PackageScreenshot, PackageUpdateTrigger, PackageUpdateConfig, \
@@ -136,10 +137,11 @@ def update_all_release_permissions(self):
 from .hashcheck import find_matches_in_zip, DatasetEntry, Hash
 
 @celery.task()
-def detect_content_in_package(package_id: int):
-	package: Package = Package.query.get(package_id)
-	if package is None:
-		raise TaskError("Unknown package")
+def detect_content_in_release(release_id: int):
+	release: PackageRelease = PackageRelease.query.get(release_id)
+	if release is None:
+		raise TaskError("Unknown release")
+	package: Package = release.package
 
 	entries = (
 		db.session.query(ContentDetectionDatasetEntry, ContentDetectionDataset.name)
@@ -152,8 +154,7 @@ def detect_content_in_package(package_id: int):
 		for pair in entries
 	]
 
-	latest_release = package.get_download_release()
-	matches = find_matches_in_zip(latest_release.file_path, entries)
+	matches = find_matches_in_zip(release.file_path, entries)
 
 	# Keep only the closest match per (content_path, hash, match_path)
 	# Added content_path here in case two copies of same image appear in same package
@@ -164,7 +165,7 @@ def detect_content_in_package(package_id: int):
 		if current is None or match.confidence < current.confidence:
 			best_by_match[key] = match
 
-	existing_detections = PackageContentDetection.query.filter_by(package_id=package_id).all()
+	existing_detections = PackageContentDetection.query.filter_by(package_id=package.id).all()
 
 	# Path-independent so a texture reviewed under an old content_path should still
 	# count as reviewed for the same hash + match_path if moved
@@ -189,7 +190,7 @@ def detect_content_in_package(package_id: int):
 			continue
 
 		detection = PackageContentDetection()
-		detection.package_id = package_id
+		detection.package_id = package.id
 		detection.content_path = match.content_path
 		detection.content_phash = match.content_phash
 		detection.content_dhash = match.content_dhash
@@ -199,6 +200,7 @@ def detect_content_in_package(package_id: int):
 		db.session.add(detection)
 
 	db.session.commit()
+	return "OK"
 
 
 

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -148,7 +148,7 @@ def detect_content_in_package(package_id: int):
 		.all())
 
 	entries = [
-		DatasetEntry(pair[1], pair[0].path, pair[0].width, pair[0].height, [Hash(hash.dhash, hash.phash) for hash in pair[0].hashes])
+		DatasetEntry(pair[1], pair[0].path, pair[0].width, pair[0].height, [Hash(hash.phash, hash.dhash) for hash in pair[0].hashes])
 		for pair in entries
 	]
 

--- a/app/tasks/importtasks.py
+++ b/app/tasks/importtasks.py
@@ -145,6 +145,7 @@ def detect_content_in_release(release_id: int):
 
 	entries = (
 		db.session.query(ContentDetectionDatasetEntry, ContentDetectionDataset.name)
+		.options(subqueryload(ContentDetectionDatasetEntry.hashes))
 		.select_from(ContentDetectionDatasetEntry)
 		.join(ContentDetectionDatasetEntry.dataset)
 		.all())

--- a/app/templates/admin/content_detection/match.html
+++ b/app/templates/admin/content_detection/match.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}
+View match
+{% endblock %}
+
+{% from "macros/forms.html" import render_field, render_submit_field %}
+
+{% block content %}
+	<h1>{{ self.title() }}</h1>
+	<dl>
+		<dt>Content Path</dt>
+		<dd>{{ match.content_path }}</dd>
+		<dt>Match Path</dt>
+		<dd>{{ match.match_path }}</dd>
+		<dt>Confidence</dt>
+		<dd>{{ match.confidence }}</dd>
+		<dt>Content PHASH</dt>
+		<dd>{{ match.content_phash }}</dd>
+		<dt>Content DHASH</dt>
+		<dd>{{ match.content_dhash }}</dd>
+	</dl>
+    <style>
+        .preview {
+            border: 1px solid #333;
+            padding: 1em;
+            background: white;
+            position: relative;
+        }
+        .preview img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            image-rendering: pixelated;
+        }
+    </style>
+
+    <div class="row">
+        <div class="col-6 preview">
+            <img src="{{ match.content_as_data_url }}" />
+        </div>
+        <div class="col-6 preview">
+            <img src="{{ match.content_as_data_url }}" />
+        </div>
+    </div>
+{% endblock %}

--- a/app/templates/admin/content_detection/match_list.html
+++ b/app/templates/admin/content_detection/match_list.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}
+List matches
+{% endblock %}
+
+{% from "macros/forms.html" import render_field, render_submit_field %}
+
+{% block content %}
+	<h1>{{ self.title() }}</h1>
+	<div class="list-group">
+		{% for match in matches %}
+			<a href="{{ url_for('admin.cd_match', match_id=match.id) }}" class="list-group-item list-group-item-action">
+				<div class="row">
+					<div class="col-auto">
+						<span class="badge bg-secondary rounded-pill me-2">{{ match.state.value }}</span>
+					</div>
+					<div class="col-5">
+						{{ match.content_path }}
+					</div>
+					<div class="col-5">
+						{{ match.match_path }}
+					</div>
+					<div class="col-1">
+						{{ match.confidence | round(1) }}
+					</div>
+				</div>
+			</a>
+		{% endfor %}
+	</div>
+{% endblock %}

--- a/migrations/versions/f4010cc844cf_.py
+++ b/migrations/versions/f4010cc844cf_.py
@@ -45,6 +45,7 @@ def upgrade():
     sa.Column('content_path', sa.String(length=200), nullable=False),
     sa.Column('content_phash', sa.String(length=200), nullable=False),
     sa.Column('content_dhash', sa.String(length=200), nullable=False),
+    sa.Column('content_data', sa.LargeBinary(), nullable=False),
     sa.Column('match_path', sa.String(length=200), nullable=False),
     sa.Column('confidence', sa.Float(), nullable=False),
     sa.Column('state', status_enum, nullable=False),

--- a/migrations/versions/f4010cc844cf_.py
+++ b/migrations/versions/f4010cc844cf_.py
@@ -16,9 +16,11 @@ branch_labels = None
 depends_on = None
 
 
+status_enum = postgresql.ENUM('NEW', 'IGNORED', 'ACCEPTED', name='contentdetectionstate', create_type=False)
+
+
 def upgrade():
-    status = postgresql.ENUM('NEW', 'IGNORED', 'ACCEPTED', name='contentdetectionstate')
-    status.create(op.get_bind())
+    status_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table('content_detection_dataset',
     sa.Column('id', sa.Integer(), nullable=False),
@@ -45,7 +47,7 @@ def upgrade():
     sa.Column('content_dhash', sa.String(length=200), nullable=False),
     sa.Column('match_path', sa.String(length=200), nullable=False),
     sa.Column('confidence', sa.Float(), nullable=False),
-    sa.Column('state', sa.Enum('NEW', 'IGNORED', 'ACCEPTED', name='contentdetectionstate'), nullable=False),
+    sa.Column('state', status_enum, nullable=False),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.ForeignKeyConstraint(['package_id'], ['package.id'], ),
     sa.PrimaryKeyConstraint('id')


### PR DESCRIPTION
- Ported most of check_package.py to the hashcheck init script
- Notably, skipped solid colors since those require the [solid templates](https://github.com/ZenonSeth/image_hash_check/tree/main/sample_colors)
- Use the results in the importtask.py file, skipping over ones that were already marked as accepted or ignored

Claude was used for some syntax in importtask.py, and to catch a bug which is why `best_by_hash = {}` was added